### PR TITLE
Add Rugplay Tracker Chrome extension

### DIFF
--- a/chromium_extension/README.md
+++ b/chromium_extension/README.md
@@ -1,0 +1,15 @@
+# Rugplay Tracker Chrome Extension
+
+This extension helps you monitor specific users and coins on [rugplay.com](https://rugplay.com).
+It periodically fetches recent trades and highlights any activity involving your tracked users or coins.
+
+## Installation
+1. Open `chrome://extensions/` in your Chromium browser.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `chromium_extension` folder.
+
+## Usage
+- Use the popup to add usernames or coin symbols you want to track.
+- The extension lists recent trades that involve those users or coins.
+
+The background service polls the Rugplay API every minute to refresh trade data.

--- a/chromium_extension/background.js
+++ b/chromium_extension/background.js
@@ -1,0 +1,26 @@
+const API_BASE = 'https://rugplay.com';
+const TRADE_ENDPOINT = `${API_BASE}/api/trades/recent?limit=100`;
+
+async function fetchTrades() {
+  try {
+    const res = await fetch(TRADE_ENDPOINT);
+    if (res.ok) {
+      const data = await res.json();
+      return data.trades || [];
+    }
+  } catch (e) {
+    console.error('Failed to fetch trades', e);
+  }
+  return [];
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create('updateTrades', { periodInMinutes: 1 });
+});
+
+chrome.alarms.onAlarm.addListener(async alarm => {
+  if (alarm.name === 'updateTrades') {
+    const trades = await fetchTrades();
+    chrome.storage.local.set({ recentTrades: trades });
+  }
+});

--- a/chromium_extension/manifest.json
+++ b/chromium_extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Rugplay Tracker",
+  "description": "Track marked users and coins on Rugplay.",
+  "version": "0.1",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://rugplay.com/*",
+    "http://localhost/*"
+  ]
+}

--- a/chromium_extension/popup.html
+++ b/chromium_extension/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 10px; }
+    input { margin-bottom: 4px; width: 100%; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+  <h2>Tracked Users</h2>
+  <input id="userInput" placeholder="Add username" />
+  <button id="addUser">Add</button>
+  <ul id="users"></ul>
+  <h2>Tracked Coins</h2>
+  <input id="coinInput" placeholder="Add coin symbol" />
+  <button id="addCoin">Add</button>
+  <ul id="coins"></ul>
+  <h2>Recent Trades</h2>
+  <ul id="trades"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chromium_extension/popup.js
+++ b/chromium_extension/popup.js
@@ -1,0 +1,74 @@
+const API_BASE = 'https://rugplay.com';
+
+function $(id) { return document.getElementById(id); }
+
+async function loadData() {
+  const data = await chrome.storage.local.get(['trackedUsers', 'trackedCoins', 'recentTrades']);
+  const users = data.trackedUsers || [];
+  const coins = data.trackedCoins || [];
+  displayList('users', users, 'user');
+  displayList('coins', coins, 'coin');
+  renderTrades(data.recentTrades || [], users, coins);
+}
+
+function displayList(elId, items, type) {
+  const ul = $(elId);
+  ul.innerHTML = '';
+  items.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    const remove = document.createElement('button');
+    remove.textContent = 'x';
+    remove.style.marginLeft = '4px';
+    remove.addEventListener('click', async () => {
+      const key = type === 'user' ? 'trackedUsers' : 'trackedCoins';
+      const list = (await chrome.storage.local.get(key))[key] || [];
+      const index = list.indexOf(item);
+      if (index > -1) { list.splice(index, 1); }
+      await chrome.storage.local.set({ [key]: list });
+      loadData();
+    });
+    li.appendChild(remove);
+    ul.appendChild(li);
+  });
+}
+
+function renderTrades(trades, users, coins) {
+  const ul = $('trades');
+  ul.innerHTML = '';
+  trades.filter(trade => {
+    const byUser = users.includes(trade.username);
+    const byCoin = coins.includes(trade.coinSymbol);
+    return byUser || byCoin;
+  }).forEach(trade => {
+    const li = document.createElement('li');
+    li.textContent = `${trade.username} ${trade.type} ${trade.amount} ${trade.coinSymbol}`;
+    ul.appendChild(li);
+  });
+}
+
+$('addUser').addEventListener('click', async () => {
+  const username = $('userInput').value.trim();
+  if (!username) return;
+  const { trackedUsers = [] } = await chrome.storage.local.get('trackedUsers');
+  if (!trackedUsers.includes(username)) {
+    trackedUsers.push(username);
+    await chrome.storage.local.set({ trackedUsers });
+  }
+  $('userInput').value = '';
+  loadData();
+});
+
+$('addCoin').addEventListener('click', async () => {
+  const coin = $('coinInput').value.trim().toUpperCase();
+  if (!coin) return;
+  const { trackedCoins = [] } = await chrome.storage.local.get('trackedCoins');
+  if (!trackedCoins.includes(coin)) {
+    trackedCoins.push(coin);
+    await chrome.storage.local.set({ trackedCoins });
+  }
+  $('coinInput').value = '';
+  loadData();
+});
+
+loadData();


### PR DESCRIPTION
## Summary
- add a `chromium_extension` directory with a minimal Chrome extension
- extension fetches recent trades and filters them by tracked users or coins
- README explains how to load and use the extension

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_685f239e4f0c832cbf02185bc550fb8f